### PR TITLE
[feature] Cleanup styling and JS Object for Type Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/home.js
+++ b/home.js
@@ -4,7 +4,7 @@ import { MDCSelect } from '@material/select';
 import FontMetrics from 'fontmetrics'
 import {MDCRipple} from '@material/ripple';
 import {MDCTextField} from '@material/textfield';
-// import { TYPOGRAPHY } from './type-vars';
+import { typography } from './type-vars';
 
 const textField = new MDCTextField(document.querySelector('.mdc-text-field'));
 const textField2 = new MDCTextField(document.querySelector('.mdc-text-field2'));
@@ -74,22 +74,6 @@ const otypeface = new MDCSelect(document.querySelector('.otypeface'));
 const oweight = new MDCSelect(document.querySelector('.oweight'));
 const osize = new MDCTextField(document.querySelector('.osize'));
 const otracking = new MDCTextField(document.querySelector('.otracking'));
-
-const SIZE_DEFAULTS_BY_TEXT_TYPE = {
-    h1: 96,
-    h2: 60,
-    h3: 48,
-    h4: 34,
-    h5: 24,
-    h6: 20,
-    body1: 16,
-    body2: 14,
-    button: 14,
-    caption: 12,
-    overline: 10,
-    subtitle1: 16,
-    subtitle2: 14,
-};
 
 const ROBOTO_X_HEIGHT_FRACTION = FontMetrics({fontFamily: 'Roboto'}).xHeight;
 
@@ -178,7 +162,8 @@ function myFunction(e) {
             fontFamily: e.currentTarget.children[1].innerText,
         });
         let textType = el.id;
-        const adjustedFont = getAdjustmentFactor(font, SIZE_DEFAULTS_BY_TEXT_TYPE[textType].size)
+        console.log(typography)
+        const adjustedFont = getAdjustmentFactor(font, typography[textType].size)
         console.log(adjustedFont);
 
         el.style.fontSize = adjustedFont + 'px';
@@ -194,7 +179,7 @@ function myFunction2(e) {
             fontFamily: e.currentTarget.children[1].innerText,
         });
         let textType = el.id;
-        const adjustedFont = getAdjustmentFactor(font, SIZE_DEFAULTS_BY_TEXT_TYPE[textType])
+        const adjustedFont = getAdjustmentFactor(font, typography[textType].size)
         console.log(adjustedFont);
 
         el.style.fontSize = adjustedFont + 'px';

--- a/home.js
+++ b/home.js
@@ -78,67 +78,54 @@ const otracking = new MDCTextField(document.querySelector('.otracking'));
 const ROBOTO_X_HEIGHT_FRACTION = FontMetrics({fontFamily: 'Roboto'}).xHeight;
 
 h1typeface.listen('MDCSelect:change', () => {
-    console.log(h1typeface.root_.parentNode.parentNode);
     h1typeface.root_.parentNode.parentNode.style.fontFamily = h1typeface.value;
 });
 
 h2typeface.listen('MDCSelect:change', () => {
-    console.log(h2typeface.root_.parentNode.parentNode);
     h2typeface.root_.parentNode.parentNode.style.fontFamily = h2typeface.value;
 });
 
 h3typeface.listen('MDCSelect:change', () => {
-    console.log(h3typeface.root_.parentNode.parentNode);
     h3typeface.root_.parentNode.parentNode.style.fontFamily = h3typeface.value;
 });
 
 h4typeface.listen('MDCSelect:change', () => {
-    console.log(h4typeface.root_.parentNode.parentNode);
     h4typeface.root_.parentNode.parentNode.style.fontFamily = h4typeface.value;
 });
 
 h5typeface.listen('MDCSelect:change', () => {
-    console.log(h5typeface.root_.parentNode.parentNode);
     h5typeface.root_.parentNode.parentNode.style.fontFamily = h5typeface.value;
 });
 
 h6typeface.listen('MDCSelect:change', () => {
-    console.log(h6typeface.root_.parentNode.parentNode);
     h6typeface.root_.parentNode.parentNode.style.fontFamily = h6typeface.value;
 });
 
 s1typeface.listen('MDCSelect:change', () => {
-    console.log(s1typeface.root_.parentNode.parentNode);
     s1typeface.root_.parentNode.parentNode.style.fontFamily = s1typeface.value;
 });
 
 s2typeface.listen('MDCSelect:change', () => {
-    console.log(s2typeface.root_.parentNode.parentNode);
     s2typeface.root_.parentNode.parentNode.style.fontFamily = s2typeface.value;
 });
 
 body1typeface.listen('MDCSelect:change', () => {
-    console.log(body1typeface.root_.parentNode.parentNode);
     body1typeface.root_.parentNode.parentNode.style.fontFamily = body1typeface.value;
 });
 
 body2typeface.listen('MDCSelect:change', () => {
-    console.log(body2typeface.root_.parentNode.parentNode);
     body2typeface.root_.parentNode.parentNode.style.fontFamily = body2typeface.value;
 });
 
 btypeface.listen('MDCSelect:change', () => {
-    console.log(btypeface.root_.parentNode.parentNode);
     btypeface.root_.parentNode.parentNode.style.fontFamily = btypeface.value;
 });
 
 ctypeface.listen('MDCSelect:change', () => {
-    console.log(ctypeface.root_.parentNode.parentNode);
     ctypeface.root_.parentNode.parentNode.style.fontFamily = ctypeface.value;
 });
 
 otypeface.listen('MDCSelect:change', () => {
-    console.log(otypeface.root_.parentNode.parentNode);
     otypeface.root_.parentNode.parentNode.style.fontFamily = otypeface.value;
 });
 
@@ -162,9 +149,7 @@ function myFunction(e) {
             fontFamily: e.currentTarget.children[1].innerText,
         });
         let textType = el.id;
-        console.log(typography)
         const adjustedFont = getAdjustmentFactor(font, typography[textType].size)
-        console.log(adjustedFont);
 
         el.style.fontSize = adjustedFont + 'px';
         el.style.fontFamily = e.currentTarget.children[1].innerText;
@@ -180,7 +165,6 @@ function myFunction2(e) {
         });
         let textType = el.id;
         const adjustedFont = getAdjustmentFactor(font, typography[textType].size)
-        console.log(adjustedFont);
 
         el.style.fontSize = adjustedFont + 'px';
         el.style.fontFamily = e.currentTarget.children[1].innerText;

--- a/home.js
+++ b/home.js
@@ -4,6 +4,7 @@ import { MDCSelect } from '@material/select';
 import FontMetrics from 'fontmetrics'
 import {MDCRipple} from '@material/ripple';
 import {MDCTextField} from '@material/textfield';
+// import { TYPOGRAPHY } from './type-vars';
 
 const textField = new MDCTextField(document.querySelector('.mdc-text-field'));
 const textField2 = new MDCTextField(document.querySelector('.mdc-text-field2'));
@@ -49,15 +50,15 @@ const s2weight = new MDCSelect(document.querySelector('.s2weight'));
 const s2size = new MDCTextField(document.querySelector('.s2size'));
 const s2tracking = new MDCTextField(document.querySelector('.s2tracking'));
 
-const b1typeface = new MDCSelect(document.querySelector('.b1typeface'));
-const b1weight = new MDCSelect(document.querySelector('.b1weight'));
-const b1size = new MDCTextField(document.querySelector('.b1size'));
-const b1tracking = new MDCTextField(document.querySelector('.b1tracking'));
+const body1typeface = new MDCSelect(document.querySelector('.body1typeface'));
+const body1weight = new MDCSelect(document.querySelector('.body1weight'));
+const body1size = new MDCTextField(document.querySelector('.body1size'));
+const body1tracking = new MDCTextField(document.querySelector('.body1tracking'));
 
-const b2typeface = new MDCSelect(document.querySelector('.b2typeface'));
-const b2weight = new MDCSelect(document.querySelector('.b2weight'));
-const b2size = new MDCTextField(document.querySelector('.b2size'));
-const b2tracking = new MDCTextField(document.querySelector('.b2tracking'));
+const body2typeface = new MDCSelect(document.querySelector('.body2typeface'));
+const body2weight = new MDCSelect(document.querySelector('.body2weight'));
+const body2size = new MDCTextField(document.querySelector('.body2size'));
+const body2tracking = new MDCTextField(document.querySelector('.body2tracking'));
 
 const btypeface = new MDCSelect(document.querySelector('.btypeface'));
 const bweight = new MDCSelect(document.querySelector('.bweight'));
@@ -81,8 +82,8 @@ const SIZE_DEFAULTS_BY_TEXT_TYPE = {
     h4: 34,
     h5: 24,
     h6: 20,
-    b1: 16,
-    b2: 14,
+    body1: 16,
+    body2: 14,
     button: 14,
     caption: 12,
     overline: 10,
@@ -132,14 +133,14 @@ s2typeface.listen('MDCSelect:change', () => {
     s2typeface.root_.parentNode.parentNode.style.fontFamily = s2typeface.value;
 });
 
-b1typeface.listen('MDCSelect:change', () => {
-    console.log(b1typeface.root_.parentNode.parentNode);
-    b1typeface.root_.parentNode.parentNode.style.fontFamily = b1typeface.value;
+body1typeface.listen('MDCSelect:change', () => {
+    console.log(body1typeface.root_.parentNode.parentNode);
+    body1typeface.root_.parentNode.parentNode.style.fontFamily = body1typeface.value;
 });
 
-b2typeface.listen('MDCSelect:change', () => {
-    console.log(b2typeface.root_.parentNode.parentNode);
-    b2typeface.root_.parentNode.parentNode.style.fontFamily = b2typeface.value;
+body2typeface.listen('MDCSelect:change', () => {
+    console.log(body2typeface.root_.parentNode.parentNode);
+    body2typeface.root_.parentNode.parentNode.style.fontFamily = body2typeface.value;
 });
 
 btypeface.listen('MDCSelect:change', () => {
@@ -177,7 +178,7 @@ function myFunction(e) {
             fontFamily: e.currentTarget.children[1].innerText,
         });
         let textType = el.id;
-        const adjustedFont = getAdjustmentFactor(font, SIZE_DEFAULTS_BY_TEXT_TYPE[textType])
+        const adjustedFont = getAdjustmentFactor(font, SIZE_DEFAULTS_BY_TEXT_TYPE[textType].size)
         console.log(adjustedFont);
 
         el.style.fontSize = adjustedFont + 'px';

--- a/home.scss
+++ b/home.scss
@@ -103,9 +103,9 @@
   @include mdc-drawer-fill-color-accessible(secondary);
   // Drawer defaults to a higher z-index, but we aren't overlaying it over anything
   @include mdc-drawer-z-index(0);
-
-
   width: 500px;
+  resize: horizontal;
+  
 
   .mdc-list {
     margin: 70px 5px auto 5px;
@@ -114,6 +114,10 @@
   .mdc-list-item {
     border-radius: 6px;
     justify-content: center;
+  }
+
+  .mdc-text-field {
+    width: 100%;
   }
 
   // This needs 3-class specificity to override MDC Drawer styles

--- a/index.html
+++ b/index.html
@@ -901,17 +901,17 @@
             </div>
           </div>
         </label>
-        <label for="b1radio" class="expansion-control">
+        <label for="body1radio" class="expansion-control">
           <div class="type-scale-item">
             <div class="type-scale-variable">
               <span>$mdc-typography--body1</span>
             </div>
-            <div id="b1" class="type-scale-example body-example"
+            <div id="body1" class="type-scale-example body-example"
               style="font-size: 16px; font-weight: normal; letter-spacing: 0.5px;">
               <span>Silver mist suffused the deck of the ship.</span>
-              <input type="radio" id="b1radio" name="exp1" class="expansion-radio">
-              <div class="type-scale-buttons tsbb1">
-                <div class="mdc-select demo-width-class b1typeface">
+              <input type="radio" id="body1radio" name="exp1" class="expansion-radio">
+              <div class="type-scale-buttons tsbbody1">
+                <div class="mdc-select demo-width-class body1typeface">
                   <input type="hidden" name="enhanced-select">
                   <i class="mdc-select__dropdown-icon"></i>
                   <div class="mdc-select__selected-text"></div>
@@ -949,7 +949,7 @@
                   <span class="mdc-floating-label">Typeface</span>
                   <div class="mdc-line-ripple"></div>
                 </div>
-                <div class="mdc-select demo-width-class b1weight">
+                <div class="mdc-select demo-width-class body1weight">
                   <input type="hidden" name="enhanced-select">
                   <i class="mdc-select__dropdown-icon"></i>
                   <div class="mdc-select__selected-text"></div>
@@ -969,13 +969,13 @@
                   <span class="mdc-floating-label">Weight</span>
                   <div class="mdc-line-ripple"></div>
                 </div>
-                <div class="mdc-text-field demo-width-class b1size">
+                <div class="mdc-text-field demo-width-class body1size">
                   <input class="mdc-text-field__input" id="text-field-hero-input">
                   <div class="mdc-line-ripple"></div>
                   <label for="text-field-hero-input"
                     class="mdc-floating-label mdc-floating-label--float-above">Size</label>
                 </div>
-                <div class="mdc-text-field demo-width-class b1tracking">
+                <div class="mdc-text-field demo-width-class body1tracking">
                   <input class="mdc-text-field__input" id="text-field-hero-input">
                   <div class="mdc-line-ripple"></div>
                   <label for="text-field-hero-input"
@@ -985,17 +985,17 @@
             </div>
           </div>
         </label>
-        <label for="b2radio" class="expansion-control">
+        <label for="body2radio" class="expansion-control">
           <div class="type-scale-item">
             <div class="type-scale-variable">
               <span>$mdc-typography--body2</span>
             </div>
-            <div id="b2" class="type-scale-example body-example"
+            <div id="body2" class="type-scale-example body-example"
               style="font-size: 14px; font-weight: normal; letter-spacing: 0.25px;">
               <span>The face of the moon was in shadow.</span>
-              <input type="radio" id="b2radio" name="exp1" class="expansion-radio">
-              <div class="type-scale-buttons tsbb2">
-                <div class="mdc-select demo-width-class b2typeface">
+              <input type="radio" id="body2radio" name="exp1" class="expansion-radio">
+              <div class="type-scale-buttons tsbbody2">
+                <div class="mdc-select demo-width-class body2typeface">
                   <input type="hidden" name="enhanced-select">
                   <i class="mdc-select__dropdown-icon"></i>
                   <div class="mdc-select__selected-text"></div>
@@ -1033,7 +1033,7 @@
                   <span class="mdc-floating-label">Typeface</span>
                   <div class="mdc-line-ripple"></div>
                 </div>
-                <div class="mdc-select demo-width-class b2weight">
+                <div class="mdc-select demo-width-class body2weight">
                   <input type="hidden" name="enhanced-select">
                   <i class="mdc-select__dropdown-icon"></i>
                   <div class="mdc-select__selected-text"></div>
@@ -1053,13 +1053,13 @@
                   <span class="mdc-floating-label">Weight</span>
                   <div class="mdc-line-ripple"></div>
                 </div>
-                <div class="mdc-text-field demo-width-class b2size">
+                <div class="mdc-text-field demo-width-class body2size">
                   <input class="mdc-text-field__input" id="text-field-hero-input">
                   <div class="mdc-line-ripple"></div>
                   <label for="text-field-hero-input"
                     class="mdc-floating-label mdc-floating-label--float-above">Size</label>
                 </div>
-                <div class="mdc-text-field demo-width-class b2tracking">
+                <div class="mdc-text-field demo-width-class body2tracking">
                   <input class="mdc-text-field__input" id="text-field-hero-input">
                   <div class="mdc-line-ripple"></div>
                   <label for="text-field-hero-input"

--- a/type-vars.js
+++ b/type-vars.js
@@ -1,4 +1,4 @@
-export default TYPOGRAPHY = {
+export const typography = {
     h1: {
         typeface: 'Roboto',
         size: 96,

--- a/type-vars.js
+++ b/type-vars.js
@@ -1,0 +1,94 @@
+export default TYPOGRAPHY = {
+    h1: {
+        typeface: 'Roboto',
+        size: 96,
+        weight: 'light',
+        tracking: -1.5,
+        transform: 'none'
+    },
+    h2: {
+        typeface: 'Roboto',
+        size: 60,
+        weight: 'light',
+        tracking: -0.5,
+        transform: 'none'
+    },
+    h3: {
+        typeface: 'Roboto',
+        size: 48,
+        weight: 'normal',
+        tracking: 0,
+        transform: 'none'
+    },
+    h4: {
+        typeface: 'Roboto',
+        size: 34,
+        weight: 'normal',
+        tracking: 0.25,
+        transform: 'none'
+    },
+    h5: {
+        typeface: 'Roboto',
+        size: 24,
+        weight: 'normal',
+        tracking: 0,
+        transform: 'none'
+    },
+    h6: {
+        typeface: 'Roboto',
+        size: 20,
+        weight: 'bold',
+        tracking: 0,
+        transform: 'none'
+    },
+    subtitle1: {
+        typeface: 'Roboto',
+        size: 16,
+        weight: 'regular',
+        tracking: 0.15,
+        transform: 'none'
+    },
+    subtitle2: {
+        typeface: 'Roboto',
+        size: 14,
+        weight: 'bold',
+        tracking: 0.1,
+        transform: 'none'
+    },
+    body1: {
+        typeface: 'Roboto',
+        size: 16,
+        weight: 'regular',
+        tracking: 0.5,
+        transform: 'none'
+    },
+    body2: {
+        typeface: 'Roboto',
+        size: 14,
+        weight: 'regular',
+        tracking: 0.25,
+        transform: 'none'
+    },
+    button: {
+        typeface: 'Roboto',
+        size: 14,
+        weight: 'regular',
+        tracking: 1.25,
+        transform: 'uppercase'
+    },
+    caption: {
+        typeface: 'Roboto',
+        size: 12,
+        weight: 'regular',
+        tracking: 0.4,
+        transform: 'none'
+    },
+    overline: {
+        typeface: 'Roboto',
+        size: 10,
+        weight: 'regular',
+        tracking: 1.5,
+        transform: 'uppercase'
+    }
+}
+


### PR DESCRIPTION
- Renamed b1 and b2 to body1 and body2 to match the rest of the naming convention (i.e. subtitle)
- Added resize to sidebar
- created `type-vars.js` as a reference store
- Moved data for size into type object
- Removing `console.log`'s